### PR TITLE
[Chrome] オプション画面で市区町村名が取れないのを修正

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -16,6 +16,7 @@
     "permissions" : [
         "tabs",
         "http://calil.jp/",
+        "https://calil.jp/",
         "http://api.calil.jp/"
     ],
     "icons" : {


### PR DESCRIPTION
2015-2016の年末年始あたりにカーリル側がcalil.jp/city_listへの接続をhttpsのみに制限したらしく、same-origin policyの関係で、市区町村のデータが取れなくなっていました。
これはCalilayのChromeウェブストアのレビューの中でも指摘されています。

その問題を、manifest.jsonのcross-origin permissionにhttps://calil.jp/ を追加することで修正しました。