### PR TITLE
[Chrome, Amazon] Kindleへの対応 & Wishlistのバグ修正

### DIFF
--- a/chrome/calilapi.js
+++ b/chrome/calilapi.js
@@ -52,7 +52,7 @@ Calil.prototype = {
 		$("#"+isbn).attr("status","");
 	},
 	search : function() {
-		var domain = "http://api.calil.jp";
+		var domain = "https://api.calil.jp";
 		var apiurl = domain + "/check?appkey="+this.appkey+"&systemid="+ this.systemid_list.join(',') +"&isbn="+ this.isbn_list.join(',');
 		this.call_api(apiurl);
 
@@ -104,7 +104,7 @@ Calil.prototype = {
 			if (this.api_call_count > 7){
 				seconds = 5000;
 			}
-			var newurl = "http://api.calil.jp/check?appkey="+this.appkey+"&session=" + session;
+			var newurl = "https://api.calil.jp/check?appkey="+this.appkey+"&session=" + session;
 			var self = this;
 			setTimeout(function(){
 				self.call_api(newurl);

--- a/chrome/calilay.js
+++ b/chrome/calilay.js
@@ -68,6 +68,19 @@ chrome.extension.sendRequest({method: "getLocalStorage", key: "libraries"}, func
             return isbnList;
         },
 
+        AmazonKindle: function () {
+            var isbnList = [];
+            $("#formats a[id^=a-autoid-").each(function(a) {
+                if ($(this).attr('href').match(/\/(?:ASIN|[dg]p)(?:\/product)?\/([\dX]{10})/)) {
+                    var isbn = RegExp.$1;
+                    isbnList.unshift(isbn);
+                    // TODO: when more than 1 ISBNs are matched, some descriptions may be needed.
+                    $('#centerCol').append(createInitialElement(isbn));
+                }
+            });
+            return $.unique(isbnList);
+        }, 
+
         AmazonWishlist: function () {
             var isbnList = [];
             $('tbody.itemWrapper').not('tbody:has(div.calilay)').each(function(i) {

--- a/chrome/calilay.js
+++ b/chrome/calilay.js
@@ -83,11 +83,12 @@ chrome.extension.sendRequest({method: "getLocalStorage", key: "libraries"}, func
 
         AmazonWishlist: function () {
             var isbnList = [];
-            $('tbody.itemWrapper').not('tbody:has(div.calilay)').each(function(i) {
-                if ($(this).attr('name').match(/\.([A-Z0-9]{10})$/)) {
+            $('#wishlist-page [id^=itemInfo_]').not(':has(div.calilay)').each(function(i) {
+                var href = $(this).find('a[id^=itemName_]').attr('href');
+                if (href && href.match(/\/(?:ASIN|[dg]p)(?:\/product)?\/([\dX]{10})/)) {
                     var isbn = RegExp.$1;
                     isbnList.unshift(isbn);
-                    $(this).find('td.lineItemMainInfo:first').append(createInitialElement(isbn));
+                    $(this).append(createInitialElement(isbn));
                 }
             });
             return $.unique(isbnList);

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -17,14 +17,16 @@
         "tabs",
         "http://calil.jp/",
         "https://calil.jp/",
-        "http://api.calil.jp/"
+        "http://api.calil.jp/",
+        "https://api.calil.jp/"
     ],
     "icons" : {
         "128" : "calilay128.png"
     },
     "content_scripts": [
         {
-            "matches": ["http://mediamarker.net/u/*", "http://www.amazon.co.jp/*", "http://book.akahoshitakuya.com/*"],
+            "matches": ["http://mediamarker.net/u/*", "http://www.amazon.co.jp/*", 
+                        "https://www.amazon.co.jp/*", "http://book.akahoshitakuya.com/*"],
             "css": ["calilapi.css"],
             "js": ["jquery-1.6.4.min.js", "calilapi.js", "sites.js", "calilay.js"],
             "run_at": "document_end"

--- a/chrome/sites.js
+++ b/chrome/sites.js
@@ -2,11 +2,15 @@ function getSiteType(url) {
     var pages = {
         MediaMarker:      /http:\/\/mediamarker\.net\/u\/.*\//,
         AmazonDetail:     /http:\/\/www\.amazon\.co\.jp\/.*(ASIN|[dg]p)(\/product)?\/[\dX]{10}/,
+        AmazonKindle:     /http:\/\/www\.amazon\.co\.jp\/.*(ASIN|[dg]p)(\/product)?\/\w{10}/,
         AmazonWishlist:   /http:\/\/www\.amazon\.co\.jp\/(.*\/)?wishlist\//,
         DockushoMeterPre: /http:\/\/book.akahoshitakuya.com\/home\?main=pre/
     };
     for (var type in pages) {
         if (pages[type].test(url)) {
+            if (type == "AmazonKindle"){
+                return $("body").hasClass("ebooks") ? type : null;
+            }
             return type;
         }
     }

--- a/chrome/sites.js
+++ b/chrome/sites.js
@@ -1,9 +1,9 @@
 function getSiteType(url) {
     var pages = {
         MediaMarker:      /http:\/\/mediamarker\.net\/u\/.*\//,
-        AmazonDetail:     /http:\/\/www\.amazon\.co\.jp\/.*(ASIN|[dg]p)(\/product)?\/[\dX]{10}/,
-        AmazonKindle:     /http:\/\/www\.amazon\.co\.jp\/.*(ASIN|[dg]p)(\/product)?\/\w{10}/,
-        AmazonWishlist:   /http:\/\/www\.amazon\.co\.jp\/(.*\/)?wishlist\//,
+        AmazonDetail:     /https?:\/\/www\.amazon\.co\.jp\/.*(ASIN|[dg]p)(\/product)?\/[\dX]{10}/,
+        AmazonKindle:     /https?:\/\/www\.amazon\.co\.jp\/.*(ASIN|[dg]p)(\/product)?\/\w{10}/,
+        AmazonWishlist:   /https?:\/\/www\.amazon\.co\.jp\/(.*\/)?wishlist\//,
         DockushoMeterPre: /http:\/\/book.akahoshitakuya.com\/home\?main=pre/
     };
     for (var type in pages) {


### PR DESCRIPTION
Amazonの本のKindle版も別フォーマットのものが図書館にないか表示するようにしました。（詳細ページ、ほしいものリスト両方に対応）
（けど、Kindle以外のフォーマットが2つ以上あるときには図書館が2重に表示されて、どのフォーマットがどの図書館表示に対応するのかが分かりません。）

更に、Amazonのほしいものリストで図書館情報が表示されないようになっていたのを修正しました。

加えて、Amazonのhttpsのページでも図書館情報が表示されるようにしました。
